### PR TITLE
:bug: Update 프로필 수정 시 uri별 파일 반환 수정

### DIFF
--- a/app/src/main/java/com/umc/anddeul/home/network/ModifyProfileInterface.kt
+++ b/app/src/main/java/com/umc/anddeul/home/network/ModifyProfileInterface.kt
@@ -13,6 +13,6 @@ interface ModifyProfileInterface {
     @PATCH("/home/user/profile")
     fun modifyProfile(
         @Part("nickname") nickname : RequestBody,
-        @Part image : MultipartBody.Part
+        @Part image : MultipartBody.Part?
     ) : Call<ModifyProfileResponse>
 }

--- a/app/src/main/java/com/umc/anddeul/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/umc/anddeul/mypage/MyPageFragment.kt
@@ -79,7 +79,7 @@ class MyPageFragment : Fragment() {
         binding.mypageModifyBtn.setOnClickListener {
             // MyPageModifyFragment로 이동
             (context as MainActivity).supportFragmentManager.beginTransaction()
-                .add(R.id.mypage_layout, MyPageModifyFragment())
+                .add(R.id.main_frm, MyPageModifyFragment())
                 .addToBackStack(null)
                 .commitAllowingStateLoss()
         }


### PR DESCRIPTION
Related to : #190


# PR 템플릿
### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
- 프로필 수정 시 사진 변경 없이 닉네임만 수정할 때 사진 uri 에러 발생
  (닉네임만 수정 시 서버에서 보내준 웹 uri를 전달해서 파일로 변환이 안됨
  -> 파일로 변환하는 함수를 로컬 uri, 웹 uri용으로 따로 구현)
  - modifyMyProfile 함수 호출 시 사진 수정하는 경우 true, 닉네임만 수정하는 경우 false 반환
  - true 시 로컬 uri 전달 -> getFileFromUri 함수 호출
  - false 시 웹 uri 전달 -> downloadImageFromWeb 함수 호출



### 피드백을 받고 싶은 부분 
<!-- 작업 후 기대 동작(스크린샷) -->
- 로컬 uri와 웹 uri를 동시에 쓸 때 이렇게 처리하는 것이 맞나요?



### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
- 231번째 라인에서 response code가 200으로 오는데 화면 전환이 될 때가 있고 안될 때가 있어요..
- 갤러리 구현은 다시 포토피커로 바꿀 예정입니다


### 특이 사항 :
Issue Number:  #190 
